### PR TITLE
save avatar_url for user

### DIFF
--- a/priv/repo/migrations/20170609201439_add_avatar_url_to_users.exs
+++ b/priv/repo/migrations/20170609201439_add_avatar_url_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Oprah.Repo.Migrations.AddAvatarUrlToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :avatar_url, :string
+    end
+  end
+end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -13,8 +13,9 @@ defmodule Oprah.SessionController do
   def callback(%{assigns: %{ueberauth_failure: %{errors: errors}}}=conn, _params) do
     render(conn, :error, errors: errors)
   end
-  def callback(%{assigns: %{ueberauth_auth: %{info: %{name: name}, uid: gitlab_id}}}=conn, _params) do
-    user = Oprah.User.user_from_uberauth_info(gitlab_id, name)
+  def callback(%{assigns: %{ueberauth_auth: %{info: %{name: name, urls: urls}, uid: gitlab_id}}}=conn, _params) do
+    avatar_url = Map.get(urls, :avatar_url)
+    user = Oprah.User.user_from_uberauth_info(gitlab_id, name, avatar_url)
     conn |> put_session(:user_id, user.id) |> put_flash(:info, "Yo #{user.name}") |> redirect(to: nomination_path(conn, :pick_a_nominee))
   end
 end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -2,6 +2,7 @@ defmodule Oprah.User do
   use Oprah.Web, :model
 
   schema "users" do
+    field :avatar_url, :string
     field :name, :string
     field :github_id, :integer
     field :gitlab_id, :integer
@@ -15,17 +16,17 @@ defmodule Oprah.User do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :github_id, :gitlab_id])
+    |> cast(params, [:name, :github_id, :gitlab_id, :avatar_url])
     |> validate_required([:name])
     |> validate_length(:name, min: 4, max: 20)
     |> unique_constraint(:name)
   end
 
-  def user_from_uberauth_info(gitlab_id, name) do
+  def user_from_uberauth_info(gitlab_id, name, avatar_url) do
     case Repo.get_by(User, gitlab_id: gitlab_id) do
-      nil -> Repo.insert!(%User{gitlab_id: gitlab_id, name: name})
+      nil -> Repo.insert!(%User{gitlab_id: gitlab_id, name: name, avatar_url: avatar_url})
       user ->
-        cast(user, %{gitlab_id: gitlab_id, name: name}, [:gitlab_id, :name])
+        cast(user, %{gitlab_id: gitlab_id, name: name, avatar_url: avatar_url}, [:gitlab_id, :name, :avatar_url])
         |> Oprah.Repo.update!
       end
   end

--- a/web/web.ex
+++ b/web/web.ex
@@ -58,7 +58,7 @@ defmodule Oprah.Web do
       import Oprah.Gettext
 
       def avatar(user, size \\ 20) do
-        tag :img, src: "https://git.moneydesktop.com/avatars/u/#{user.id}", width: size
+        tag :img, src: user.avatar_url, width: size
       end
 
       def markdown_render(str) do


### PR DESCRIPTION
I have found a nice easy way to build the avatar_url from a gitlab user_id. However, it is returned on the OAUTH request, so might as well just capture it and save with the user.

@mmmries 